### PR TITLE
Add basic Binance trading bot script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,21 @@
 # trading
+
 auto trading system
+
+## Requirements
+- Python 3.9+
+- Dependencies listed in `requirements.txt`
+
+## Usage
+1. Install dependencies
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Run the bot
+   ```bash
+   python bot.py
+   ```
+   The script will prompt for API key/secret and order details.
+
+## Disclaimer
+Use at your own risk. Cryptocurrency trading involves significant risk; test thoroughly and prefer Binance testnet before trading real funds.

--- a/bot.py
+++ b/bot.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Simple Binance trading bot.
+
+DISCLAIMER:
+- Cryptocurrency trading involves significant risk.
+- Use this script for learning purposes only.
+- Test thoroughly (preferably on Binance testnet) before real trades.
+"""
+
+import getpass
+
+try:
+    from binance.client import Client
+    from binance.enums import SIDE_BUY, SIDE_SELL, ORDER_TYPE_MARKET
+except ModuleNotFoundError as exc:
+    raise ModuleNotFoundError(
+        "Missing dependency 'python-binance'. Install it with "
+        "'pip install -r requirements.txt'."
+    ) from exc
+
+
+def create_client() -> Client:
+    """Prompt for API credentials and create a Binance Client."""
+    api_key = input("Enter Binance API Key: ").strip()
+    api_secret = getpass.getpass("Enter Binance API Secret: ").strip()
+    if not api_key or not api_secret:
+        raise ValueError("Both API key and secret are required.")
+    return Client(api_key, api_secret)
+
+
+def place_market_order(client: Client, symbol: str, side: str, quantity: float):
+    """Place a market order via Binance API."""
+    side_enum = SIDE_BUY if side.lower() == "buy" else SIDE_SELL
+    order = client.create_order(
+        symbol=symbol.upper(),
+        side=side_enum,
+        type=ORDER_TYPE_MARKET,
+        quantity=quantity,
+    )
+    return order
+
+
+def main() -> None:
+    """Run the bot once: prompt for order details and execute."""
+    client = create_client()
+    symbol = input("Symbol (e.g., BTCUSDT): ").strip()
+    side = input("Side (buy/sell): ").strip().lower()
+    quantity = float(input("Quantity: "))
+    order = place_market_order(client, symbol, side, quantity)
+    print("Order executed:", order)
+
+
+if __name__ == "__main__":
+    main()

--- a/bot.py
+++ b/bot.py
@@ -9,6 +9,9 @@ DISCLAIMER:
 
 import getpass
 
+# Wrap third-party imports to surface a helpful message when the
+# `python-binance` package is not installed instead of failing with a
+# cryptic error.
 try:
     from binance.client import Client
     from binance.enums import SIDE_BUY, SIDE_SELL, ORDER_TYPE_MARKET

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+python-binance


### PR DESCRIPTION
## Summary
- add simple bot script that prompts for Binance API credentials and places market orders
- document requirements, usage, and risk disclaimer
- provide requirements.txt and handle missing python-binance dependency gracefully

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile bot.py`


------
https://chatgpt.com/codex/tasks/task_e_689ca485f718832d901df925905623ea